### PR TITLE
Added collapse functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @geoffcox/react-splitter
+# @geoffcox/react-splitter (Collapsible edition)
 
-A resizable splitter for React that leverages CSS display:grid
+A resizable and collapsible splitter for React that leverages CSS display:grid
 
 [Live Demo](https://geoffcox.github.io/react-splitter-demo/index.html)
 

--- a/package/README.md
+++ b/package/README.md
@@ -1,6 +1,7 @@
 # @geoffcox/react-splitter
 
 A resizable splitter for React that leverages CSS display:grid
+Now with collapse functionality
 
 [Live Demo](https://geoffcox.github.io/react-splitter-demo/index.html)
 
@@ -118,13 +119,14 @@ const renderSplitter = (props: RenderSplitterProps) => {
 </Split>
 ```
 
-The callback receives the `RenderSplitterProps` to let you know the current size of the splitter, if the split is horizontal, and if the splitter is currently being dragged.
+The callback receives the `RenderSplitterProps` to let you know the current size of the splitter, if the split is horizontal, if the splitter is currently being dragged, and if the splitter is in a collapsed state.
 
 ```ts
 export type RenderSplitterProps = {
   pixelSize: number;
   horizontal: boolean;
   dragging: boolean;
+  collapsed: boolean;
 };
 ```
 
@@ -145,6 +147,21 @@ const onMeasuredSizesChanged = (sizes: SplitMeasuredPixelSizes) => {
 <Split onSplitChanged={onSplitChanged} onMeasuredSizesChanged={onMeasuredSizesChanged}>
   <div>Primary pane</div>
   <div>Secondary pane<div>
+</Split>
+```
+
+## Collapse panel
+You can make one of the panels collapsible.
+You can collapse a panel by clicking on it. 
+Use the prop `collapsible` to enable collapse for one of the panels. 
+Possible values are `none`, `primary` and `secondary`. 
+
+```tsx
+<Split
+    collapsible={'secondary'}
+    splitterSize="24px">
+    <div>Primary pane</div>
+    <div>Secondary pane<div>
 </Split>
 ```
 # Integrating into a web application

--- a/package/src/DefaultSplitter.tsx
+++ b/package/src/DefaultSplitter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RenderSplitterProps } from './RenderSplitterProps';
-//import './defaultSplitter.css';
+import './defaultSplitter.css';
 
 const getThinLineSize = (size: number) => `${size % 2 === 0 ? 2 : 3}px`;
 const getCenteredMargin = (size: number) => `${Math.max(0, Math.floor(size / 2) - 1)}px`;

--- a/package/src/DefaultSplitter.tsx
+++ b/package/src/DefaultSplitter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RenderSplitterProps } from './RenderSplitterProps';
-import './defaultSplitter.css';
+//import './defaultSplitter.css';
 
 const getThinLineSize = (size: number) => `${size % 2 === 0 ? 2 : 3}px`;
 const getCenteredMargin = (size: number) => `${Math.max(0, Math.floor(size / 2) - 1)}px`;

--- a/package/src/RenderSplitterProps.ts
+++ b/package/src/RenderSplitterProps.ts
@@ -14,4 +14,9 @@ export type RenderSplitterProps = {
    * True if the user is currently dragging the splitter; false otherwise.
    */
   dragging: boolean;
+
+  /**
+   * True if the splitter is in a collapsed state; false otherwise.
+   */
+  collapsed: boolean;
 };

--- a/package/src/Split.tsx
+++ b/package/src/Split.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { default as Measure, ContentRect } from 'react-measure';
 import { DefaultSplitter } from './DefaultSplitter';
 import { RenderSplitterProps } from './RenderSplitterProps';
-//import './split.css';
+import './split.css';
 
 type MeasuredDimensions = {
   height: number;


### PR DESCRIPTION
You can now make one of the panels collapsible.
You can collapse a panel by clicking on it. 
Use the prop `collapsible` to enable collapse for one of the panels. 
Possible values are `none`, `primary` and `secondary`. 

```tsx
<Split
    collapsible={'secondary'}
    splitterSize="24px">
    <div>Primary pane</div>
    <div>Secondary pane<div>
</Split>
```
